### PR TITLE
Changed 'force_text' to 'force_str'

### DIFF
--- a/accounts/views.py
+++ b/accounts/views.py
@@ -1,7 +1,7 @@
 from django.contrib.auth import login, authenticate
 from django.shortcuts import render, redirect, get_object_or_404, HttpResponseRedirect
 from django.contrib.sites.shortcuts import get_current_site
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str
 from django.contrib.auth.models import User
 from django.db import IntegrityError
 from django.utils.http import urlsafe_base64_decode
@@ -22,7 +22,7 @@ def activation_sent_view(request):
 
 def activate(request, uidb64, token):
     try:
-        uid = force_text(urlsafe_base64_decode(uidb64))
+        uid = force_str(urlsafe_base64_decode(uidb64))
         user = User.objects.get(pk=uid)
     except (TypeError, ValueError, OverflowError, User.DoesNotExist):
         user = None


### PR DESCRIPTION
Just a minor change cause in Django 4.0 we don't have force_text but rather force_str